### PR TITLE
Adds `is_allocated()` and `reset()` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.1.3] - 2025-07-14
+
+### Added
+
+- `is_allocated()` method for all memory map types to check allocation status of specific indices
+- `reset()` method for all memory map types to clear all allocations and return to initial state
+
 ## [v0.1.2] - 2025-07-04
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "index-mem-alloc"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 description = "Index memory allocator"
 authors = ["Deriverse <info@deriverse.io>"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,11 @@
 mod get_first_zero_bit;
 mod max_memory_map;
 mod small_memory_map;
-mod trade_memory_map;
+mod standard_memory_map;
 
 use crate::{
     max_memory_map::MaxMemoryMap, small_memory_map::SmallMemoryMap,
-    trade_memory_map::StandardMemoryMap,
+    standard_memory_map::StandardMemoryMap,
 };
 use solana_program::account_info::AccountInfo;
 use std::{
@@ -122,6 +122,15 @@ impl MemoryMap {
             Self::Max(map) => map.is_allocated(index),
             Self::Standard(map) => map.is_allocated(index),
             Self::Small(map) => map.is_allocated(index),
+        }
+    }
+
+    /// Reset all allocations, clearing the entire memory map
+    pub fn reset(&mut self) -> Result<(), MemoryMapError> {
+        match self {
+            Self::Max(map) => map.reset(),
+            Self::Standard(map) => map.reset(),
+            Self::Small(map) => map.reset(),
         }
     }
 }

--- a/src/max_memory_map.rs
+++ b/src/max_memory_map.rs
@@ -107,6 +107,29 @@ impl MaxMemoryMap {
 
         Ok(is_allocated)
     }
+
+    /// Reset all allocations, clearing the entire memory map
+    pub(crate) fn reset(&mut self) -> Result<(), MemoryMapError> {
+        // Clear first level (1 word)
+        let first_word = get_u64_mut(self.memory, self.size, 0)?;
+        *first_word = 0;
+
+        // Clear second level (BITS_PER_LEVEL words)
+        for i in 1..=BITS_PER_LEVEL {
+            let second_word = get_u64_mut(self.memory, self.size, i)?;
+            *second_word = 0;
+        }
+
+        // Clear third level (BITS_PER_LEVEL * BITS_PER_LEVEL words)
+        let third_level_start = 1 + BITS_PER_LEVEL;
+        let third_level_count = BITS_PER_LEVEL * BITS_PER_LEVEL;
+        for i in 0..third_level_count {
+            let third_word = get_u64_mut(self.memory, self.size, third_level_start + i)?;
+            *third_word = 0;
+        }
+
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -542,5 +565,17 @@ pub(crate) mod tests {
             !map.is_allocated(MAX_INDEX).unwrap(),
             "MAX_INDEX should not be allocated yet"
         );
+
+        // Reset
+        map.reset().unwrap();
+
+        // Verify all are unallocated
+        for &idx in &test_indices {
+            assert!(
+                !map.is_allocated(idx).unwrap(),
+                "Index {} should be unallocated after reset",
+                idx
+            );
+        }
     }
 }

--- a/src/small_memory_map.rs
+++ b/src/small_memory_map.rs
@@ -86,6 +86,21 @@ impl SmallMemoryMap {
 
         Ok(is_allocated)
     }
+
+    /// Reset all allocations, clearing the entire memory map
+    pub fn reset(&mut self) -> Result<(), MemoryMapError> {
+        // Clear first level (1 word)
+        let first_word = get_u64_mut(self.memory, self.size, 0)?;
+        *first_word = 0;
+
+        // Clear second level (BITS_PER_LEVEL words)
+        for i in 1..=BITS_PER_LEVEL {
+            let second_word = get_u64_mut(self.memory, self.size, i)?;
+            *second_word = 0;
+        }
+
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -314,5 +329,17 @@ mod tests {
             !map.is_allocated(MAX_INDEX).unwrap(),
             "MAX_INDEX should not be allocated yet"
         );
+
+        // Reset
+        map.reset().unwrap();
+
+        // Verify all are unallocated
+        for &idx in &test_indices {
+            assert!(
+                !map.is_allocated(idx).unwrap(),
+                "Index {} should be unallocated after reset",
+                idx
+            );
+        }
     }
 }

--- a/src/standard_memory_map.rs
+++ b/src/standard_memory_map.rs
@@ -106,6 +106,29 @@ impl StandardMemoryMap {
 
         Ok(is_allocated)
     }
+
+    /// Reset all allocations, clearing the entire memory map
+    pub(crate) fn reset(&mut self) -> Result<(), MemoryMapError> {
+        // Clear first level (1 word)
+        let first_word = get_u64_mut(self.memory, self.size, 0)?;
+        *first_word = 0;
+
+        // Clear second level (FIRST_LEVEL_BITS words)
+        for i in 1..=FIRST_LEVEL_BITS {
+            let second_word = get_u64_mut(self.memory, self.size, i)?;
+            *second_word = 0;
+        }
+
+        // Clear third level (FIRST_LEVEL_BITS * SECOND_LEVEL_BITS words)
+        let third_level_start = 1 + FIRST_LEVEL_BITS;
+        let third_level_count = FIRST_LEVEL_BITS * SECOND_LEVEL_BITS;
+        for i in 0..third_level_count {
+            let third_word = get_u64_mut(self.memory, self.size, third_level_start + i)?;
+            *third_word = 0;
+        }
+
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -335,5 +358,17 @@ mod tests {
             !map.is_allocated(MAX_INDEX).unwrap(),
             "MAX_INDEX should not be allocated yet"
         );
+
+        // Reset
+        map.reset().unwrap();
+
+        // Verify all are unallocated
+        for &idx in &test_indices {
+            assert!(
+                !map.is_allocated(idx).unwrap(),
+                "Index {} should be unallocated after reset",
+                idx
+            );
+        }
     }
 }


### PR DESCRIPTION
Adds `is_allocated()` and `reset()` methods to all memory map types:

- Implements `is_allocated()` to check the allocation status of specific indices.
- Implements `reset()` to clear all allocations and return to the initial state.
- Renames `trade_memory_map` to `standard_memory_map` for clarity.
- Increments crate version to 0.1.3.